### PR TITLE
Add proxy layer for MIDI playback

### DIFF
--- a/android/src/com/morpheme/palmpiano/PalmPiano.java
+++ b/android/src/com/morpheme/palmpiano/PalmPiano.java
@@ -18,7 +18,9 @@ import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.morpheme.palmpiano.midi.MidiComposer;
 import com.morpheme.palmpiano.midi.MidiFileIO;
 import com.morpheme.palmpiano.midi.MidiFileParser;
+import com.morpheme.palmpiano.midi.MidiNotePlayback;
 import com.morpheme.palmpiano.midi.MidiPlayback;
+import com.morpheme.palmpiano.midi.MidiPlaybackProxy;
 import com.morpheme.palmpiano.midi.Note;
 import com.morpheme.palmpiano.util.Constants;
 import com.pdrogfer.mididroid.MidiFile;
@@ -333,9 +335,8 @@ public class PalmPiano implements ApplicationListener {
 				break;
 			case MODE_GAME:
 			case MODE_PLAYBACK:
-				MidiFile midiFile = MidiFileIO.getMidiFile(context, (String) bundle.getSerializable("midiFile"));
-				List<Note> midiNotes = MidiFileParser.getMidiEvents(midiFile);
-				MidiPlayback playback = new MidiPlayback(mode, midiNotes, MidiPlayback.BOTH_HANDS);
+				MidiNotePlayback playback = new MidiPlaybackProxy(mode, MidiPlayback.BOTH_HANDS, context, (String) bundle.getSerializable("midiFile"));
+				EventBus.getInstance().register(playback);
 				Thread midiThread = new Thread(playback);
 				midiThread.start();
 				break;

--- a/android/src/com/morpheme/palmpiano/midi/MidiNotePlayback.java
+++ b/android/src/com/morpheme/palmpiano/midi/MidiNotePlayback.java
@@ -1,0 +1,10 @@
+package com.morpheme.palmpiano.midi;
+
+import com.morpheme.palmpiano.EventListener;
+
+import java.util.List;
+
+public interface MidiNotePlayback extends EventListener, Runnable {
+    void playbackMidi();
+    void setMidiNotes(List<Note> midiNoteEvents);
+}

--- a/android/src/com/morpheme/palmpiano/midi/MidiPlaybackProxy.java
+++ b/android/src/com/morpheme/palmpiano/midi/MidiPlaybackProxy.java
@@ -1,0 +1,120 @@
+package com.morpheme.palmpiano.midi;
+
+import android.content.Context;
+
+import com.morpheme.palmpiano.Event;
+import com.morpheme.palmpiano.EventBus;
+import com.morpheme.palmpiano.PalmPiano;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class MidiPlaybackProxy implements MidiNotePlayback {
+    private MidiNotePlayback actualPlayback;
+
+    private HashSet<Event.EventType> monitoredEvents;
+    private PalmPiano.PianoMode mode;
+    private int hand;
+    private List<Note> notes;
+    private boolean isPlaying;
+
+    private Context context;
+    private String midiFileName;
+
+    public MidiPlaybackProxy(PalmPiano.PianoMode mode, int hand, Context context, String midiFileName) {
+        this(mode, hand, null);
+        this.context = context;
+        this.midiFileName = midiFileName;
+    }
+
+    public MidiPlaybackProxy(PalmPiano.PianoMode mode, int hand, List<Note> midiNotes) {
+        // Data to store when actual object is needed
+        this.mode = mode;
+        this.hand = hand;
+        this.notes = midiNotes;
+        this.context = null;
+        this.midiFileName = null;
+
+        // Un-instantiated actual object
+        this.actualPlayback = null;
+
+        // Dummy data to return when actual object not yet instantiated
+        this.monitoredEvents = new HashSet<>();
+        this.monitoredEvents.add(Event.EventType.MIDI_FILE_PLAY);
+        this.monitoredEvents.add(Event.EventType.MIDI_FILE_PAUSE);
+        this.isPlaying = false;
+    }
+
+    @Override
+    public void playbackMidi() {
+        if (actualPlayback != null) {
+            actualPlayback.playbackMidi();
+        }
+        else {
+            System.out.println("Proxy playbackMidi");
+            // Virtual proxy behaviour; only instantiate and run upon beginning to play
+            while (!this.isPlaying) {}
+            System.out.println("Proxy continuing playback");
+            if (notes == null) {
+                System.out.println("Proxy actual init: " + mode + ", " + hand + ", " + context + ", " + midiFileName);
+                actualPlayback = new MidiPlayback(mode, hand, context, midiFileName);
+            } else {
+                actualPlayback = new MidiPlayback(mode, hand, notes);
+            }
+            actualPlayback.handleEvent(new Event<>(Event.EventType.MIDI_FILE_PLAY, null));
+            actualPlayback.playbackMidi();
+        }
+    }
+
+    @Override
+    public void setMidiNotes(List<Note> midiNoteEvents) {
+        if (actualPlayback != null) {
+            actualPlayback.setMidiNotes(midiNoteEvents);
+        }
+        else {
+            notes = midiNoteEvents;
+        }
+    }
+
+    @Override
+    public void handleEvent(Event<?> event) {
+        System.out.println("Proxy handleEvent: " + event.toString());
+        if (actualPlayback != null) {
+            actualPlayback.handleEvent(event);
+        }
+        else {
+            switch (event.getEventType()) {
+                case MIDI_FILE_PLAY:
+                    this.isPlaying = true;
+                    System.out.println("Proxy isPlaying=true");
+                    break;
+                case MIDI_FILE_PAUSE:
+                    this.isPlaying = false;
+                    System.out.println("Proxy isPlaying=false");
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public Set<Event.EventType> getMonitoredEvents() {
+        if (actualPlayback != null) {
+            return actualPlayback.getMonitoredEvents();
+        }
+        return monitoredEvents;
+    }
+
+    @Override
+    public void run() {
+        if (actualPlayback != null) {
+            actualPlayback.run();
+        }
+        else {
+            System.out.println("Proxy running...");
+            playbackMidi();
+        }
+    }
+}

--- a/android/src/com/morpheme/palmpiano/midi/MidiPlaybackProxy.java
+++ b/android/src/com/morpheme/palmpiano/midi/MidiPlaybackProxy.java
@@ -52,12 +52,9 @@ public class MidiPlaybackProxy implements MidiNotePlayback {
             actualPlayback.playbackMidi();
         }
         else {
-            System.out.println("Proxy playbackMidi");
             // Virtual proxy behaviour; only instantiate and run upon beginning to play
             while (!this.isPlaying) {}
-            System.out.println("Proxy continuing playback");
             if (notes == null) {
-                System.out.println("Proxy actual init: " + mode + ", " + hand + ", " + context + ", " + midiFileName);
                 actualPlayback = new MidiPlayback(mode, hand, context, midiFileName);
             } else {
                 actualPlayback = new MidiPlayback(mode, hand, notes);
@@ -79,7 +76,6 @@ public class MidiPlaybackProxy implements MidiNotePlayback {
 
     @Override
     public void handleEvent(Event<?> event) {
-        System.out.println("Proxy handleEvent: " + event.toString());
         if (actualPlayback != null) {
             actualPlayback.handleEvent(event);
         }
@@ -87,11 +83,9 @@ public class MidiPlaybackProxy implements MidiNotePlayback {
             switch (event.getEventType()) {
                 case MIDI_FILE_PLAY:
                     this.isPlaying = true;
-                    System.out.println("Proxy isPlaying=true");
                     break;
                 case MIDI_FILE_PAUSE:
                     this.isPlaying = false;
-                    System.out.println("Proxy isPlaying=false");
                     break;
                 default:
                     break;
@@ -113,7 +107,6 @@ public class MidiPlaybackProxy implements MidiNotePlayback {
             actualPlayback.run();
         }
         else {
-            System.out.println("Proxy running...");
             playbackMidi();
         }
     }


### PR DESCRIPTION
Add proxy layer to interface MIDI playback so that the instantiation,
reading, and processing of MIDI files/playback data is performed when
needed (i.e. when the play button is initially pressed to begin
playback).