### PR TITLE
Fix bug with rhythm boxes upon second entry

### DIFF
--- a/android/src/com/morpheme/palmpiano/PalmPiano.java
+++ b/android/src/com/morpheme/palmpiano/PalmPiano.java
@@ -49,7 +49,6 @@ public class PalmPiano implements ApplicationListener {
 
 		List<PianoKey> wks = new ArrayList<>();
 		List<PianoKey> bks = new ArrayList<>();
-		List<RhythmBox> boxes = new ArrayList<>();
 
 		for (int oc = 0; oc < 7; oc++) {
 			boolean bk;
@@ -89,14 +88,6 @@ public class PalmPiano implements ApplicationListener {
 					break;
 				case MODE_GAME:
 					System.out.println("Detected game mode");
-
-					for (int oc = 0; oc < 7; oc++) {
-						RhythmBox box = new RhythmBox(false, 21, 1);
-						box.setTouchable(Touchable.enabled);
-						boxes.add(box);
-						stage.addActor(box);
-					}
-
 					EventBus.getInstance().dispatch(new Event<>(Event.EventType.NEW_MIDI_FILE, (String) bundle.getSerializable("midiFile")));
 					break;
 				case MODE_PLAYBACK:

--- a/android/src/com/morpheme/palmpiano/RhythmBox.java
+++ b/android/src/com/morpheme/palmpiano/RhythmBox.java
@@ -27,17 +27,17 @@ public class RhythmBox extends Actor {
         this.duration = duration;
         this.actorY = 1300;
 
-        if (textureWk == null || textureBk == null) {
-            textureWk = new Texture(Gdx.files.internal("t1.png"));
-            textureBk = new Texture(Gdx.files.internal("t2.png"));
-        }
-
         addListener(new InputListener() {
             public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
                 ((RhythmBox)event.getTarget()).started = true;
                 return true;
             }
         });
+    }
+
+    public static void setTextures() {
+        textureWk = new Texture(Gdx.files.internal("t1.png"));
+        textureBk = new Texture(Gdx.files.internal("t2.png"));
     }
 
     // FIXME - Magic Eyeball

--- a/android/src/com/morpheme/palmpiano/RhythmBox.java
+++ b/android/src/com/morpheme/palmpiano/RhythmBox.java
@@ -4,8 +4,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
-import com.badlogic.gdx.scenes.scene2d.InputEvent;
-import com.badlogic.gdx.scenes.scene2d.InputListener;
 
 public class RhythmBox extends Actor {
     private boolean bk;
@@ -26,13 +24,6 @@ public class RhythmBox extends Actor {
         this.actorX = notePosition;
         this.duration = duration;
         this.actorY = 1300;
-
-        addListener(new InputListener() {
-            public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
-                ((RhythmBox)event.getTarget()).started = true;
-                return true;
-            }
-        });
     }
 
     public static void setTextures() {

--- a/android/src/com/morpheme/palmpiano/RhythmBoxListener.java
+++ b/android/src/com/morpheme/palmpiano/RhythmBoxListener.java
@@ -30,6 +30,7 @@ public class RhythmBoxListener implements EventListener {
         switch (event.getEventType()) {
             case NEW_STAGE:
                 this.stage = (Stage) event.getData();
+                RhythmBox.setTextures();
                 break;
             case MIDI_DATA_GAMEPLAY:
                 data = (byte[]) event.getData();


### PR DESCRIPTION
Fix bug where textures load uncoloured (i.e. black) upon second entry to
game mode and consecutive entries thereafter.

Remove unnecessary rhythm boxes during startup of game mode.